### PR TITLE
Add Streamlit dashboard and bot integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ sqlalchemy>=1.4.0
 psycopg2-binary>=2.9.0
 redis>=4.3.0
 celery>=5.2.0
-pydantic>=1.8.0 
+pydantic>=1.8.0
+streamlit>=1.30.0

--- a/src/streamlit_report.py
+++ b/src/streamlit_report.py
@@ -1,0 +1,78 @@
+import json
+import glob
+import os
+from pathlib import Path
+
+import streamlit as st
+import matplotlib.pyplot as plt
+import plotly.graph_objects as go
+
+from portfolio_optimizer import load_price_data, backtest_strategy
+
+RESULTS_PATH = Path("data/portfolio_results.json")
+
+
+def load_results():
+    if RESULTS_PATH.exists():
+        with open(RESULTS_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    st.error("Results file not found")
+    return None
+
+
+def load_latest_prices():
+    csv_files = glob.glob("data/sp500_ml_ready*.csv")
+    if not csv_files:
+        return None
+    latest = max(csv_files, key=os.path.getctime)
+    return load_price_data(latest)
+
+
+def performance_chart(prices, weights):
+    cum_returns = backtest_strategy(prices, weights)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    cum_returns.plot(ax=ax)
+    ax.set_title("Накопительная доходность")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Cumulative Return")
+    st.pyplot(fig)
+
+
+def allocation_pie(weights):
+    labels = list(weights.keys())
+    sizes = [v * 100 for v in weights.values()]
+    fig = go.Figure(data=[go.Pie(labels=labels, values=sizes, hole=0.4)])
+    fig.update_layout(title="Оптимальная аллокация (%)")
+    st.plotly_chart(fig)
+
+
+def main():
+    results = load_results()
+    if not results:
+        return
+
+    st.title("Отчёт по портфелю")
+    st.metric("Ожидаемая доходность", f"{results['expected_return']*100:.2f}%")
+    st.metric("Волатильность", f"{results['expected_volatility']*100:.2f}%")
+    st.metric("Sharpe Ratio", f"{results['sharpe_ratio']:.2f}")
+
+    prices = load_latest_prices()
+    if prices is not None:
+        st.subheader("Доходность портфеля")
+        performance_chart(prices, results['optimal_weights'])
+    else:
+        st.warning("Не удалось найти ценовые данные для построения графика доходности")
+
+    st.subheader("Структура портфеля")
+    allocation_pie(results['optimal_weights'])
+
+
+if __name__ == "__main__":
+    from streamlit.web import cli as stcli
+    import sys
+
+    if st._is_running_with_streamlit:
+        main()
+    else:
+        sys.argv = ["streamlit", "run", __file__]
+        sys.exit(stcli.main())

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -165,6 +165,7 @@ async def menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Обработка callback-запросов из inline-клавиатуры"""
+    global portfolio_results
     query = update.callback_query
     await query.answer()
     data = query.data
@@ -219,7 +220,6 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             }
             with open(PORTFOLIO_RESULTS_FILE, 'w', encoding='utf-8') as f:
                 json.dump(new_results, f, ensure_ascii=False, indent=2)
-            global portfolio_results
             portfolio_results = new_results
             lines = [
                 f"🏦 Ожидаемая доходность: {result['expected_return']*100:.2f}%",
@@ -236,7 +236,10 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text = f"❌ Ошибка при оптимизации: {e}"
         await query.edit_message_text(text)
     elif data == "menu_reports":
-        await query.edit_message_text("📄 Формирую отчёт... (заглушка)")
+        link = get_dashboard_link()
+        await query.edit_message_text(
+            f"📄 Отчёт доступен по ссылке:\n{link}"
+        )
     elif data == "menu_notifications":
         await query.edit_message_text("🔔 Управление уведомлениями... (заглушка)")
     elif data == "menu_settings":

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -65,5 +65,5 @@ def create_pdf_report(results: Dict, perf_path: str, alloc_path: str, output_pat
 
 
 def get_dashboard_link() -> str:
-    """Возвращает ссылку на веб-дашборд (заглушка)"""
-    return 'https://example.com/dashboard' 
+    """Возвращает ссылку на локальный Streamlit дашборд"""
+    return 'http://localhost:8501'


### PR DESCRIPTION
## Summary
- install Streamlit
- provide Streamlit-based dashboard for portfolio results
- link Telegram bot reports menu to the local dashboard

## Testing
- `python -m py_compile src/streamlit_report.py src/visualization.py src/telegram_bot.py`