### PR TITLE
Implement CatBoost forecasting helper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ redis>=4.3.0
 celery>=5.2.0
 pydantic>=1.8.0
 streamlit>=1.30.0
+catboost>=1.2

--- a/src/forecast.py
+++ b/src/forecast.py
@@ -1,0 +1,42 @@
+"""Вспомогательные функции для прогнозирования доходности акций."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from catboost import CatBoostRegressor
+
+
+DATA_FILE = Path("data/stocks_with_indicators_20.csv")
+
+
+def _load_features(ticker: str, data_file: Path = DATA_FILE) -> pd.DataFrame:
+    """Возвращает последнюю строку признаков для указанного тикера."""
+
+    df = pd.read_csv(data_file)
+    df_ticker = df[df["symbol"] == ticker]
+    if df_ticker.empty:
+        raise ValueError(f"Нет данных для тикера {ticker}")
+
+    features = df_ticker.drop(
+        columns=["Date", "symbol", "future_price", "annual_return"], errors="ignore"
+    )
+    return features.tail(1)
+
+
+def predict_with_catboost(ticker: str, data_file: Path | None = None) -> float:
+    """Загружает модель CatBoost и возвращает прогноз доходности."""
+
+    model_path = Path("models") / f"catboost_{ticker}.cbm"
+    if not model_path.exists():
+        raise FileNotFoundError(f"Модель для {ticker} не найдена: {model_path}")
+
+    model = CatBoostRegressor()
+    model.load_model(model_path)
+
+    features = _load_features(ticker, data_file or DATA_FILE)
+    prediction = model.predict(features)
+    return float(prediction[0])
+

--- a/src/llm_agents.py
+++ b/src/llm_agents.py
@@ -14,6 +14,7 @@ from portfolio_optimizer import (
     calculate_returns,
     calculate_var_cvar,
 )
+from forecast import predict_with_catboost
 
 
 @dataclass
@@ -42,9 +43,17 @@ def function_tool(func: Callable[..., Dict]) -> Callable[..., Dict]:
 
 @function_tool
 def forecast_tool(tickers: List[str], horizon: str) -> Dict:
-    """Dummy forecast tool returning zero growth."""
-    # Placeholder: replace with a real forecast model
-    return {ticker: 0.0 for ticker in tickers}
+    """Возвращает прогноз доходности по списку тикеров."""
+
+    results: Dict[str, float | str] = {}
+    for ticker in tickers:
+        try:
+            results[ticker] = predict_with_catboost(ticker)
+        except FileNotFoundError as exc:
+            results[ticker] = f"модель отсутствует: {exc}"
+        except Exception as exc:  # noqa: BLE001
+            results[ticker] = f"ошибка прогноза: {exc}"
+    return results
 
 
 @function_tool


### PR DESCRIPTION
## Summary
- add `catboost` dependency
- implement forecasting utilities in `forecast.py`
- use CatBoost models in `forecast_tool`

## Testing
- `flake8 src` *(fails: command not found)*
- `pytest -q`